### PR TITLE
Allow use of DocPad variables in LESS

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,11 @@
     "less": "~1.4.2"
   },
   "devDependencies": {
-    "coffee-script": "~1.6.2"
+    "coffee-script": "~1.6.2",
+    "joe": "~1.3.2",
+    "joe-reporter-console": "~1.2.1",
+    "chai": "~1.8.1",
+    "docpad": ">=6.37 <7"
   },
   "main": "./out/less.plugin.js",
   "scripts": {

--- a/test/docpad.cson
+++ b/test/docpad.cson
@@ -1,0 +1,8 @@
+# DocPad Configuration File
+# http://docpad.org/docs/config
+
+templateData:
+  site:
+    title: "DocPad LESS Renderer"
+    url: "http://github.com/docpad/docpad-plugin-less"
+    background: "yellow"

--- a/test/src/documents/less.css.less
+++ b/test/src/documents/less.css.less
@@ -2,4 +2,8 @@ body {
 	strong {
 		font-weight:bold;
 	}
+	
+	background-color: @{site.background};
 }
+
+


### PR DESCRIPTION
This currently does not work, but it would be cool if it did. Wasn't quite sure how to inject the variable into the parser.
