### PR TITLE
Update to remove .cssmin support

### DIFF
--- a/src/less.plugin.coffee
+++ b/src/less.plugin.coffee
@@ -21,7 +21,7 @@ module.exports = (BasePlugin) ->
 			{inExtension,outExtension,templateData,file} = opts
 
 			# Check extensions
-			if inExtension is 'less' and outExtension in ['css','cssmin',null]
+			if inExtension is 'less' and outExtension in ['css',null]
 				# Requires
 				path = require('path')
 				less = require('less')


### PR DESCRIPTION
docpad-plugin-cssmin now acts on `.css` files rather than the `.css.cssmin` convention.
