### PR TITLE
Remove referencesOthers toggle

### DIFF
--- a/src/less.plugin.coffee
+++ b/src/less.plugin.coffee
@@ -33,10 +33,6 @@ module.exports = (BasePlugin) ->
 				# Extend Parser Options
 				parseOptions[key] = value  for own key,value of config.parseOptions  if config.parseOptions
 
-				# Add Reference Others if this document does
-				# As lesscss concats imports
-				file.setMetaDefaults('referencesOthers': true)  if opts.content.indexOf('@import') isnt -1
-
 				# Parse
 				new (less.Parser)(parseOptions).parse opts.content, (err,tree) ->
 					# Check


### PR DESCRIPTION
The [referenceOthers](https://github.com/docpad/docpad-plugin-less/blob/master/src/less.plugin.coffee#L36) toggle is as follows:

``` coffeescript
# Add Reference Others if this document does
# As lesscss concats imports
file.setMetaDefaults('referencesOthers': true)  if opts.content.indexOf('@import') isnt -1
```

This tells DocPad to rebuild all documents if `@import` is anywhere in the document. There are two cases of using a `@import` in a LESS file:
1. Importing a LESS file. This will make LESS concatinate and re-build the LESS file for us.
2. Importing a CSS file. LESS will ignore concatenation and just leave the CSS as a CSS import.

In either case, it seems like LESS will do the work for us, DocPad does not have to rebuild anything else. We don't need the referencesOthers toggle at all, since LESS does the rebuilding for us. I suggest we remove it, and just default to referencesOthers false. LESS handles importing/building LESS files for us.
